### PR TITLE
add support  Android Studio Koala Feature Drop | 2024.1.2  (update libs local version)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.programmersbox"
-version = "1.0.28"
+version = "1.0.29"
 
 repositories {
     mavenCentral()
@@ -42,7 +42,7 @@ dependencies {
     implementation(compose.desktop.windows_x64)
     implementation(compose.desktop.common)
     implementation(compose.materialIconsExtended)
-    val ktorVersion = "2.3.7"
+    val ktorVersion = "2.3.12"
     implementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
@@ -66,7 +66,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("221")
-        untilBuild.set("241.*")
+        untilBuild.set("245.*")
     }
 
     signPlugin {

--- a/src/main/kotlin/com/programmersbox/fullmultiplatformcompose/BuilderParams.kt
+++ b/src/main/kotlin/com/programmersbox/fullmultiplatformcompose/BuilderParams.kt
@@ -10,7 +10,7 @@ class BuilderParams {
     var hasiOS: Boolean by mutableStateOf(false)
     var hasDesktop: Boolean by mutableStateOf(false)
 
-    var packageName by mutableStateOf("com.example")
+    var packageName by mutableStateOf("idv.neo.compose")
     var sharedName by mutableStateOf("common")
 
     val android = Android()
@@ -28,7 +28,7 @@ class Android {
 }
 
 class IOS {
-    var appName: String by mutableStateOf("My Application")
+    var appName: String by mutableStateOf("CMP_With_KMP App")
 }
 
 class Compose {

--- a/src/main/kotlin/com/programmersbox/fullmultiplatformcompose/BuilderWizardBuilder.kt
+++ b/src/main/kotlin/com/programmersbox/fullmultiplatformcompose/BuilderWizardBuilder.kt
@@ -135,7 +135,7 @@ class BuilderWizardBuilder : StarterModuleBuilder() {
     }
 
     override fun getTemplateProperties(): Map<String, Any> {
-        val versions = runBlocking { network.getVersions(params.remoteVersions) }
+        val versions = runBlocking { network.getVersions(params.remoteVersions) }//FIXME
         val sanitizedPackageName = sanitizePackage(starterContext.artifact)
         return mapOf(
             PACKAGE_NAME to starterContext.group,

--- a/src/main/kotlin/com/programmersbox/fullmultiplatformcompose/utils/NetworkVersions.kt
+++ b/src/main/kotlin/com/programmersbox/fullmultiplatformcompose/utils/NetworkVersions.kt
@@ -41,11 +41,13 @@ class NetworkVersions {
 
 @Serializable
 data class ProjectVersions(
-    val kotlinVersion: String = "1.9.10",
-    val agpVersion: String = "7.3.0",
-    val composeVersion: String = "1.5.10",
-    val androidxAppCompat: String = "1.6.1",
-    val androidxCore: String = "1.10.1",
-    val ktor: String = "2.3.6",
-    val koin: String = "3.4.0",
+    val kotlinVersion: String = "2.0.20",
+    val agpVersion: String = "8.5.0",
+    val composeVersion: String = "1.6.11",
+    val androidxAppCompat: String = "1.7.0",
+    val androidxCore: String = "1.13.1",
+    val ktor: String = "2.3.12",
+    val koin: String = "3.5.3",
+    val ktorfit: String = "1.12.0",
+    val napier: String = "2.6.1",
 )

--- a/src/main/resources/fileTemplates/code/android_build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/code/android_build.gradle.kts.ft
@@ -1,22 +1,23 @@
 plugins {
-    id("org.jetbrains.compose")
     id("com.android.application")
     kotlin("android")
+    id("org.jetbrains.compose")
+    alias(libs.plugins.compose.compiler)
 }
 
 group = "${PACKAGE_NAME}"
 version = "1.0-SNAPSHOT"
 
-repositories {
-    mavenCentral()
-}
 
 android {
     compileSdk = 34
+    namespace = "${PACKAGE_NAME}.${LAST_PACKAGE_NAME}"
+    buildFeatures {
+            compose = true
+    }
     defaultConfig {
         applicationId = "${PACKAGE_NAME}.${LAST_PACKAGE_NAME}"
         minSdk = ${MINSDK}
-            targetSdk = 34
         versionCode = 1
         versionName = "1.0-SNAPSHOT"
     }

--- a/src/main/resources/fileTemplates/code/android_manifest.xml.ft
+++ b/src/main/resources/fileTemplates/code/android_manifest.xml.ft
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${PACKAGE_NAME}.${LAST_PACKAGE_NAME}">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
             android:label="${APP_NAME}"

--- a/src/main/resources/fileTemplates/code/common_android_manifest.xml.ft
+++ b/src/main/resources/fileTemplates/code/common_android_manifest.xml.ft
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="${PACKAGE_NAME}.${SHARED_NAME}"/>
+<manifest />

--- a/src/main/resources/fileTemplates/code/common_build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/code/common_build.gradle.kts.ft
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose")
+    alias(libs.plugins.compose.compiler)
     #if (${HAS_ANDROID})
     id("com.android.library")
     #end
@@ -67,7 +68,7 @@ kotlin {
                     api(libs.ktor.core)
                 #end
                 #if (${USE_KOIN})
-                    api(libs.koinCore)
+                    api(libs.koin.core)
                 #end
             }
         }
@@ -82,7 +83,7 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 api(libs.androidx.appcompat)
-                api(libs.androidx.core)
+                api(libs.androidx.core.ktx)
                 #if (${USE_KTOR})
                     api(libs.ktor.jvm)
                 #end
@@ -138,10 +139,10 @@ kotlin {
 #if (${HAS_ANDROID})
 android {
     compileSdk = 34
+    namespace = "${PACKAGE_NAME}.${SHARED_NAME}"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = ${MINSDK}
-            targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/resources/fileTemplates/code/desktop_build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/code/desktop_build.gradle.kts.ft
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose")
+    alias(libs.plugins.compose.compiler)
 }
 
 group = "${PACKAGE_NAME}"

--- a/src/main/resources/fileTemplates/code/js_build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/code/js_build.gradle.kts.ft
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose")
+    alias(libs.plugins.compose.compiler)
 }
 
 kotlin {

--- a/src/main/resources/fileTemplates/code/libs.versions.toml.ft
+++ b/src/main/resources/fileTemplates/code/libs.versions.toml.ft
@@ -15,28 +15,33 @@ koin-version = "${KOIN}"
 #if (${HAS_ANDROID})
 android-application = { id = "com.android.application", version.ref = "agp.version" }
 android-library = { id = "com.android.library", version.ref = "agp.version" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin.version" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin.version" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin.version" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin.version" }
+jetbrains_kotlin_serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin.version" }
+kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin_version" }
 #end
 
 [libraries]
 #if (${USE_KTOR})
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor.version" }
-    #if (${HAS_ANDROID} || ${HAS_DESKTOP})
-    ktor-jvm = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor.version" }
-    #end
-    #if(${HAS_WEB})
-    ktor-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor.version" }
-    ktor-jsonjs = { module = "io.ktor:ktor-client-json-js", version.ref = "ktor.version" }
-    #end
-    #if (${HAS_IOS})
-    ktor-ios = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor.version" }
-    #end
+#if (${HAS_ANDROID} || ${HAS_DESKTOP})
+ktor-jvm = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor.version" }
+#end
+#if(${HAS_WEB})
+ktor-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor.version" }
+ktor-jsonjs = { module = "io.ktor:ktor-client-json-js", version.ref = "ktor.version" }
+#end
+#if (${HAS_IOS})
+ktor-ios = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor.version" }
+#end
 #end
 #if (${USE_KOIN})
-koinCore = { module = "io.insert-koin:koin-core", version.ref = "koin.version" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin.version" }
 #end
 #if (${HAS_ANDROID})
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "${androidxAppCompat}" }
-androidx-core = { module = "androidx.core:core-ktx", version = "${androidxCore}" }
-androidx-activity-compose = "androidx.activity:activity-compose:1.7.2"
+androidx-core-ktx = { module = "androidx.core:core-ktx", version = "${androidxCore}" }
+androidx-activity-compose = "androidx.activity:activity-compose:1.9.2"
 #end

--- a/src/main/resources/fileTemplates/code/project_build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/code/project_build.gradle.kts.ft
@@ -1,14 +1,5 @@
 group = "${PACKAGE_NAME}"
 version = "1.0-SNAPSHOT"
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-    }
-}
-
 plugins {
     kotlin("jvm") version libs.versions.kotlin.version.get() apply false
     kotlin("multiplatform") version libs.versions.kotlin.version.get() apply false
@@ -18,4 +9,18 @@ plugins {
         alias(libs.plugins.kotlin.android) apply false
     #end
     id("org.jetbrains.compose") version libs.versions.compose.version.get() apply false
+    alias(libs.plugins.compose.compiler).apply(false)
+    #if (${HAS_IOS})
+        alias(libs.plugins.kotlin.cocoapods).apply(false)
+    #end
+}
+
+buildscript {
+    dependencies {
+
+    }
+}
+
+allprojects {
+
 }

--- a/src/main/resources/fileTemplates/code/project_gradle.properties.ft
+++ b/src/main/resources/fileTemplates/code/project_gradle.properties.ft
@@ -1,4 +1,6 @@
+org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 kotlin.code.style=official
+android.useAndroidX=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.binary.memoryModel=experimental
@@ -6,5 +8,3 @@ kotlin.mpp.enableCInteropCommonization=true
 xcodeproj=iosApp
 kotlin.native.cocoapods.generate.wrapper=true
 kotlin.native.useEmbeddableCompilerJar=true
-android.useAndroidX=true
-org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"

--- a/src/main/resources/fileTemplates/code/project_settings.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/code/project_settings.gradle.kts.ft
@@ -1,12 +1,48 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     repositories {
-        google()
         gradlePluginPortal()
+        maven(url = "https://plugins.gradle.org/m2/")
+        google{
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+            mavenContent{
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven(url = "https://jitpack.io")
+        maven(url = "https://s3.amazonaws.com/repo.commonsware.com")
+        maven(url = "https://jogamp.org/deployment/maven")
+    }
+    plugins {
+
     }
 }
 
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositories {
+        google {
+            mavenContent{
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        maven(url = "https://jitpack.io")
+        maven(url = "https://s3.amazonaws.com/repo.commonsware.com")
+        maven(url = "https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven(url = "https://jogamp.org/deployment/maven")
+    }
+}
 rootProject.name = "${APP_NAME}"
 
 #if (${HAS_ANDROID})

--- a/versions.json
+++ b/versions.json
@@ -1,9 +1,11 @@
 {
-  "kotlinVersion": "1.9.10",
-  "agpVersion": "7.3.0",
-  "composeVersion": "1.5.10",
-  "androidxAppCompat": "1.6.1",
-  "androidxCore": "1.10.1",
+  "kotlinVersion": "2.0.20",
+  "agpVersion": "8.5.0",
+  "composeVersion": "1.6.11",
+  "androidxAppCompat": "1.7.0",
+  "androidxCore": "1.13.1",
   "ktor": "2.3.6",
-  "koin": "3.4.0"
+  "koin": "3.4.0",
+  "ktorfit": "1.12.0",
+  "napier": "2.6.1"
 }


### PR DESCRIPTION
Dear Sir

1.  modify untilBuild  -- like  152cd48c8135cb591df42bb44ed079871d593e1f

2.  update local lib version :  ProjectVersions &  versions.json <-- some suguest 

__bug & issue ___

1. use this plugin create project lost "gradle/wrapper/gradle-wrapper.properties" --> at kotlin 1.9.10 will let iOS build fail  / over kotlin 2.0.0 will let "project init fail" .  can fix it ?

2. when kotlin 2.0.0 the compose compiler(Ref : https://developer.android.com/jetpack/androidx/releases/compose-compiler & https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html#migrating-a-jetpack-compose- ) merge to kotlin  maybe the UI can set kotlin version ? when over 2.0.0 will add compose compiler pluigin ?
and enable "composeResources" !! ( the project template can use default icon for AD for you )

3.  the ktor /koin version use "https://raw.githubusercontent.com/jakepurple13/Full-Multiplatform-Compose-Plugin/main/versions.json" is hard code !!  can modify to real check ? ( ref : https://github.com/gradle-plugins/portal-api ) & the UI  can like set AppName or packagename ?  when check "use remote source" call api get ?

4. the DI (dependency injection) can let switch ?  koin & hilt ?

5. can like Android Template(Ref : https://github.com/cnrture/QuickProjectWizard/tree/main/src/main/kotlin/com/github/cnrture/quickprojectwizard/arch. 
 & https://developer.android.com/studio/projects/templates) create "MVVM" Template ?
 
 